### PR TITLE
Support for PKCE (RFC 7636)

### DIFF
--- a/core/src/main/resources/db/migration/V4__pkce_support.sql
+++ b/core/src/main/resources/db/migration/V4__pkce_support.sql
@@ -1,4 +1,3 @@
-ALTER TABLE code ADD COLUMN code_challenge VARCHAR(128) NULL;
-ALTER TABLE code ADD COLUMN code_challenge_method VARCHAR(16) NULL;
+ALTER TABLE code ADD COLUMN code_challenge VARCHAR(140) NULL;
 
 ALTER TABLE client MODIFY COLUMN secret CHAR(32) NULL;

--- a/core/src/main/resources/db/migration/V4__pkce_support.sql
+++ b/core/src/main/resources/db/migration/V4__pkce_support.sql
@@ -1,2 +1,4 @@
 ALTER TABLE code ADD COLUMN code_challenge VARCHAR(128) NULL;
 ALTER TABLE code ADD COLUMN code_challenge_method VARCHAR(16) NULL;
+
+ALTER TABLE client MODIFY COLUMN secret CHAR(32) NULL;

--- a/core/src/main/resources/db/migration/V4__pkce_support.sql
+++ b/core/src/main/resources/db/migration/V4__pkce_support.sql
@@ -1,0 +1,2 @@
+ALTER TABLE code ADD COLUMN code_challenge VARCHAR(128) NULL;
+ALTER TABLE code ADD COLUMN code_challenge_method VARCHAR(16) NULL;

--- a/core/src/main/scala/se/su/dsv/oauth/Client.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/Client.scala
@@ -1,12 +1,22 @@
 package se.su.dsv.oauth
 
 import org.http4s.Uri
+import se.su.dsv.oauth.Client.Confidential
 
 import scala.collection.immutable.Set
 
-final case class Client(
-  name: String,
-  secret: String,
-  allowedScopes: Set[String],
-  redirectUri: Uri
-)
+sealed trait Client {
+  def isConfidential: Boolean = this match {
+    case _: Client.Public => false
+    case _: Client.Confidential => true
+  }
+
+  def allowedScopes: Set[String]
+
+  def redirectUri: Uri
+}
+
+object Client {
+  final case class Confidential(name: String, secret: String, allowedScopes: Set[String], redirectUri: Uri) extends Client
+  final case class Public(name: String, allowedScopes: Set[String], redirectUri: Uri) extends Client
+}

--- a/core/src/main/scala/se/su/dsv/oauth/Client.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/Client.scala
@@ -10,6 +10,8 @@ sealed trait Client {
     case _: Client.Public => false
     case _: Client.Confidential => true
   }
+  
+  def isPublic: Boolean = !isConfidential
 
   def allowedScopes: Set[String]
 

--- a/core/src/main/scala/se/su/dsv/oauth/Code.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/Code.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import org.http4s._
 
-final case class Code(redirectUri: Option[Uri], uuid: UUID, payload: Payload)
+final case class Code(redirectUri: Option[Uri], uuid: UUID, payload: Payload, proofKey: Option[ProofKey])
 
 object Code {
   implicit object instances extends QueryParam[Code] with QueryParamEncoder[Code] {

--- a/core/src/main/scala/se/su/dsv/oauth/Code.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/Code.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import org.http4s._
 
-final case class Code(redirectUri: Option[Uri], uuid: UUID, payload: Payload, proofKey: Option[ProofKey])
+final case class Code(redirectUri: Option[Uri], uuid: UUID, payload: Payload, codeChallenge: Option[CodeChallenge])
 
 object Code {
   implicit object instances extends QueryParam[Code] with QueryParamEncoder[Code] {

--- a/core/src/main/scala/se/su/dsv/oauth/DatabaseBackend.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/DatabaseBackend.scala
@@ -54,7 +54,7 @@ class DatabaseBackend[F[_]](xa: Transactor[F])(implicit S: Sync[F]) {
   def getPayload(token: Token): OptionT[F, Payload] =
     OptionT(for {
       now <- S.delay(Instant.now())
-      payload <- queries.getPayload(token, now).option.transact(xa)
+      payload <- queries.getPayload(token.token, now).option.transact(xa)
     } yield payload)
 
   def introspect(token: Token): F[Introspection] =
@@ -107,7 +107,7 @@ object DatabaseBackend {
          """
         .query[Code]
 
-    def getPayload(token: Token, now: Instant): Query0[Payload] =
+    def getPayload(token: String, now: Instant): Query0[Payload] =
       sql"""SELECT principal, display_name, mail, entitlements FROM token WHERE uuid = $token AND expires > $now"""
         .query[Payload]
   }

--- a/core/src/main/scala/se/su/dsv/oauth/administration/AdminDatabaseBackend.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/administration/AdminDatabaseBackend.scala
@@ -20,7 +20,7 @@ class AdminDatabaseBackend[F[_]](xa: Transactor[F])(implicit S: Sync[F]) {
     for {
       clientId <- alphaNum(36)
       clientSecret <- alphaNum(32)
-      _ <- queries.insertClient(owner, clientId, clientSecret, name, redirectUri, scopes)
+      _ <- queries.insertClient(owner, clientId, Some(clientSecret), name, redirectUri, scopes)
         .run
         .transact(xa)
     } yield Client(clientId, name)
@@ -48,7 +48,7 @@ class AdminDatabaseBackend[F[_]](xa: Transactor[F])(implicit S: Sync[F]) {
 
   def updateClient(owner: Principal,
                    clientId: String,
-                   secret: String,
+                   secret: Option[String],
                    name: String,
                    redirectUri: String,
                    scopes: Set[String]): F[ClientDetails] =
@@ -58,7 +58,7 @@ class AdminDatabaseBackend[F[_]](xa: Transactor[F])(implicit S: Sync[F]) {
       .transact(xa)
 
   def updateClient(clientId: String,
-                   secret: String,
+                   secret: Option[String],
                    name: String,
                    redirectUri: String,
                    scopes: Set[String]): F[ClientDetails] =
@@ -80,7 +80,7 @@ object AdminDatabaseBackend {
       sql"""select uuid, name from client where owner = $owner"""
         .query[Client]
 
-    def insertClient(owner: Principal, clientId: String, clientSecret: String, name: String, redirectUri: String, scopes: Set[String]): Update0 =
+    def insertClient(owner: Principal, clientId: String, clientSecret: Option[String], name: String, redirectUri: String, scopes: Set[String]): Update0 =
       sql"""insert into client (owner, name, uuid, secret, redirect_uri, scopes)
             values ($owner, $name, $clientId, $clientSecret, $redirectUri, $scopes)"""
         .update
@@ -99,7 +99,7 @@ object AdminDatabaseBackend {
 
     def updateClient(owner: Principal,
                      clientId: String,
-                     secret: String,
+                     secret: Option[String],
                      name: String,
                      redirectUri: String,
                      scopes: Set[String]): Update0 =
@@ -108,7 +108,7 @@ object AdminDatabaseBackend {
         .update
 
     def updateClient(clientId: String,
-                     secret: String,
+                     secret: Option[String],
                      name: String,
                      redirectUri: String,
                      scopes: Set[String]): Update0 =

--- a/core/src/main/scala/se/su/dsv/oauth/administration/ClientDetails.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/administration/ClientDetails.scala
@@ -1,3 +1,3 @@
 package se.su.dsv.oauth.administration
 
-final case class ClientDetails(id: String, name: String, secret: String, scopes: Set[String], redirectUri: String)
+final case class ClientDetails(id: String, name: String, secret: Option[String], scopes: Set[String], redirectUri: String)

--- a/core/src/main/scala/se/su/dsv/oauth/endpoint/AbstractAuthorize.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/endpoint/AbstractAuthorize.scala
@@ -1,0 +1,75 @@
+package se.su.dsv.oauth.endpoint
+
+import cats.data.{EitherT, OptionT}
+import cats.data.OptionT.{none, some}
+import cats.effect.Concurrent
+import cats.syntax.all.*
+import org.http4s.{Response, Uri}
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Location
+import se.su.dsv.oauth.{AuthorizationRequest, Client, Code, GeneratedToken, Payload, ResponseType}
+
+sealed trait AuthorizationRequestError
+case class NoSuchClient(str: String) extends AuthorizationRequestError
+case class InvalidScopes(requested: Set[String], allowed: Set[String]) extends AuthorizationRequestError
+case class InvalidRedirectUri(requested: Option[Uri], allowed: Uri) extends AuthorizationRequestError
+
+class AbstractAuthorize[F[_] : Concurrent]
+(lookupClient: String => OptionT[F, Client],
+ generateToken: Payload => F[GeneratedToken],
+ generateCode: (String, Option[Uri], Payload) => F[Code])
+  extends Http4sDsl[F] {
+
+  def authorize(authorizationRequest: AuthorizationRequest, payload: Payload): F[Response[F]] = {
+    val response = for {
+      client <- lookupClient(authorizationRequest.clientId)
+        .toRight(NoSuchClient(authorizationRequest.clientId))
+      _ <- validateScopes(authorizationRequest.scopes, client.allowedScopes)
+        .toRight[AuthorizationRequestError](InvalidScopes(
+          requested = authorizationRequest.scopes,
+          allowed = client.allowedScopes
+        ))
+      redirectUri <- validateRedirectUri(authorizationRequest.redirectUri, client.redirectUri)
+        .toRight(InvalidRedirectUri(
+          requested = authorizationRequest.redirectUri,
+          allowed = client.redirectUri
+        ))
+      callbackUri <- EitherT.liftF(authorizationRequest.responseType match {
+        case ResponseType.Code =>
+          for {
+            code <- generateCode(authorizationRequest.clientId, authorizationRequest.redirectUri, payload)
+          } yield redirectUri +*? code +?? ("state", authorizationRequest.state)
+        case ResponseType.Token =>
+          generateToken(payload) map { token =>
+            val parameters = Map(
+              "access_token" -> token.token.token,
+              "token_type" -> "Bearer",
+              "expires_in" -> String.valueOf(token.duration.getSeconds),
+              "state" -> authorizationRequest.state.getOrElse("")
+            )
+            redirectUri.copy(
+              fragment = Some(parameters.foldLeft("") { case (s, (key, value)) => s"$s&$key=$value" })
+            )
+          }
+      })
+    } yield callbackUri
+    response.foldF(
+      error => Forbidden(error.toString),
+      uri => SeeOther(Location(uri)))
+  }
+
+  private def validateScopes(requestedScopes: Set[String], allowedScopes: Set[String]): OptionT[F, Set[String]] = {
+    if (requestedScopes.forall(allowedScopes))
+      some(requestedScopes)
+    else
+      none
+  }
+
+  def validateRedirectUri(requestedRedirectUri: Option[Uri], configuredRedirectUri: Uri): OptionT[F, Uri] = {
+    val redirectUri = requestedRedirectUri getOrElse configuredRedirectUri
+    if (redirectUri == configuredRedirectUri)
+      some(redirectUri)
+    else
+      none
+  }
+}

--- a/core/src/main/scala/se/su/dsv/oauth/endpoint/Administration.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/endpoint/Administration.scala
@@ -14,7 +14,7 @@ class Administration[F[_]]
   ( listClients: Principal => F[List[Client]]
   , lookupClient: (Principal, String) => F[Option[ClientDetails]]
   , registerClient: (Principal, String, String, Set[String]) => F[Client]
-  , updateClient: (Principal, String, String, String, String, Set[String])  => F[ClientDetails]
+  , updateClient: (Principal, String, Option[String], String, String, Set[String])  => F[ClientDetails]
   )
   (implicit A: Concurrent[F])
   extends Http4sDsl[F]
@@ -53,7 +53,8 @@ class Administration[F[_]]
             updatedClient = for {
               name <- form.getFirst("name")
               redirectUri <- form.getFirst("redirectUri")
-              secret <- form.getFirst("secret")
+              secret = form.getFirst("secret")
+                .filter(_.length == 32)
               scopes = form.getFirst("scopes").map(_.linesIterator.toSet).getOrElse(Set.empty)
             } yield {
               updateClient(principal, clientId, secret, name, redirectUri, scopes) flatMap { client =>

--- a/core/src/main/scala/se/su/dsv/oauth/endpoint/Exchange.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/endpoint/Exchange.scala
@@ -89,7 +89,7 @@ class Exchange[F[_] : Concurrent]
         val challengeHash = Base64.getUrlDecoder.decode(challenge)
         val digest = java.security.MessageDigest.getInstance("SHA-256")
         val codeHash = digest.digest(code.getBytes(StandardCharsets.UTF_8))
-        if challengeHash == codeHash then
+        if java.util.Arrays.equals(challengeHash, codeHash) then
           EitherT.rightT(())
         else
           EitherT.leftT(AccessTokenRequest.invalidGrant)

--- a/core/src/main/scala/se/su/dsv/oauth/request.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/request.scala
@@ -66,7 +66,8 @@ object ProofKey {
 
 final case class AccessTokenRequest private (
   code: String,
-  redirectUri: Option[Uri]
+  redirectUri: Option[Uri],
+  codeVerifier: Option[String]
 )
 object AccessTokenRequest {
   sealed trait ErrorResponse
@@ -97,7 +98,8 @@ object AccessTokenRequest {
         if grantType == "authorization_code"
         code <- form.getFirst("code")
         redirectUri = form.getFirst("redirect_uri").flatMap(Uri.fromString(_).toOption)
-      } yield AccessTokenRequest(code, redirectUri)
+        codeVerifier = form.getFirst("code_verifier")
+      } yield AccessTokenRequest(code, redirectUri, codeVerifier)
     }
     for {
       form <- EntityDecoder[F, UrlForm]

--- a/core/src/main/scala/se/su/dsv/oauth/request.scala
+++ b/core/src/main/scala/se/su/dsv/oauth/request.scala
@@ -10,7 +10,6 @@ import org.http4s.{EntityDecoder, Request, Uri, UrlForm}
 sealed trait ResponseType
 object ResponseType {
   case object Code extends ResponseType
-  case object Token extends ResponseType
 }
 
 final case class AuthorizationRequest private (
@@ -31,7 +30,6 @@ object AuthorizationRequest {
     for {
       responseType <- getParam("response_type").flatMap {
         case "code" => Some(ResponseType.Code)
-        case "token" => Some(ResponseType.Token)
         case _ => None
       }
       clientId <- getParam("client_id")

--- a/core/src/main/twirl/administration/client.scala.html
+++ b/core/src/main/twirl/administration/client.scala.html
@@ -14,7 +14,7 @@
             <dd>@client.id</dd>
 
             <dt>Client secret</dt>
-            <dd>@client.secret</dd>
+            <dd>@client.secret.getOrElse("<Public client>")</dd>
 
             <dt>Redirect URI</dt>
             <dd>@client.redirectUri</dd>
@@ -39,9 +39,14 @@
             <br>
             <label>
                 Client secret
-                <input type="text" name="secret" required minlength="32" maxlength="32" value="@client.secret" size="32" pattern="[a-zA-Z0-9]+" autocomplete="off">
+                <input type="text" name="secret"  maxlength="32" value="@client.secret" size="32" pattern="[a-zA-Z0-9]+" autocomplete="off">
                 <small>a-z A-Z 0-9, 32 characters</small>
             </label>
+            <p>
+                Leave secret blank to make this a public client.
+                Public clients must use code grant with PKCE.
+                Still have to use HTTP basic authorization to identify client id, password is ignored.
+            </p>
             <br>
             <label>
                 Redirect URI

--- a/core/src/test/scala/se/su/dsv/oauth/DatabaseBackendSuite.scala
+++ b/core/src/test/scala/se/su/dsv/oauth/DatabaseBackendSuite.scala
@@ -24,7 +24,7 @@ class DatabaseBackendSuite extends AnyFunSuite with IOChecker {
   test("purge expired tokens") { check(queries.purgeExpiredTokens(null)) }
   test("store token")          { check(queries.storeToken(null, Payload(null, null, null, null), null)) }
   test("purge expired codes")  { check(queries.purgeExpiredCodes(null)) }
-  test("store code")           { check(queries.storeCode(null, null, null, Payload(null, null, null, null), null, null, null)) }
+  test("store code")           { check(queries.storeCode(null, null, null, Payload(null, null, null, null), null, null)) }
   test("lookup code")          { check(queries.lookupCode(null, null, null)) }
   test("get payload")          { check(queries.getPayload(null, null)) }
   test("introspect token")     { check(queries.getTokenDetails(null)) }

--- a/core/src/test/scala/se/su/dsv/oauth/DatabaseBackendSuite.scala
+++ b/core/src/test/scala/se/su/dsv/oauth/DatabaseBackendSuite.scala
@@ -24,7 +24,7 @@ class DatabaseBackendSuite extends AnyFunSuite with IOChecker {
   test("purge expired tokens") { check(queries.purgeExpiredTokens(null)) }
   test("store token")          { check(queries.storeToken(null, Payload(null, null, null, null), null)) }
   test("purge expired codes")  { check(queries.purgeExpiredCodes(null)) }
-  test("store code")           { check(queries.storeCode(null, null, null, Payload(null, null, null, null), null)) }
+  test("store code")           { check(queries.storeCode(null, null, null, Payload(null, null, null, null), null, null, null)) }
   test("lookup code")          { check(queries.lookupCode(null, null, null)) }
   test("get payload")          { check(queries.getPayload(null, null)) }
   test("introspect token")     { check(queries.getTokenDetails(null)) }

--- a/core/src/test/scala/se/su/dsv/oauth/endpoint/ExchangeSuite.scala
+++ b/core/src/test/scala/se/su/dsv/oauth/endpoint/ExchangeSuite.scala
@@ -1,0 +1,129 @@
+package se.su.dsv.oauth.endpoint
+
+import cats.data.OptionT
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import io.circe.Json
+import org.http4s.circe._
+import org.http4s.headers.Authorization
+import org.http4s.{BasicCredentials, Method, Request, Status, UrlForm}
+import org.http4s.syntax.literals.uri
+import org.scalatest.{Inside, OptionValues}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import se.su.dsv.oauth.*
+
+import java.time.Duration
+import java.util.UUID
+
+class ExchangeSuite extends AnyWordSpec with Matchers with Inside with OptionValues {
+  "Exchange endpoint" when {
+    "client and code is valid" should {
+      val localhost = uri"http://localhost"
+
+      val client1 = Client("client-1", "client-1-secret", Set(), localhost)
+      val client2 = Client("client-2", "client-2-secret", Set(), localhost)
+
+      val payload = Payload("test@localhost", Some("Test Testsson"), None, Entitlements(List(s"$entitlementPrefix:test-runner")))
+
+      val codeWithoutRedirectWithoutPKCE = Code(None, UUID.randomUUID(), payload, None)
+      val codeWithRedirectWithoutPKCE = Code(Some(localhost), UUID.randomUUID(), payload, None)
+
+      val plainProofKey = "plain-proof-key"
+      val codeWithPlainPKCE = Code(None, UUID.randomUUID(), payload, Some(ProofKey.Plain(plainProofKey)))
+
+      val token = GeneratedToken(Token("token"), Duration.ofHours(1))
+
+      val clients = Map[String, (Client, List[Code])](
+        client1.name -> (client1, List(codeWithoutRedirectWithoutPKCE, codeWithRedirectWithoutPKCE)),
+        client2.name -> (client2, List(codeWithPlainPKCE)))
+
+      val exchange = new Exchange[IO](
+        clientId => OptionT.fromOption(clients.get(clientId).map(_._1)),
+        (clientId, code) => OptionT.fromOption(clients.get(clientId).flatMap((_, codes) => codes.find(_.uuid.toString == code))),
+        _ => token.pure
+      ).service.orNotFound
+
+      "reject exchange if redirect uri does not match" in {
+        val request: Request[IO] = Request(method = Method.POST)
+          .putHeaders(Authorization(BasicCredentials(client1.name, client1.secret)))
+          .withEntity(UrlForm(
+            ("grant_type", "authorization_code"),
+            ("code", codeWithRedirectWithoutPKCE.uuid.toString)))
+
+        val response = exchange.run(request).unsafeRunSync()
+
+        response.status should be(Status.BadRequest)
+
+        val json = response.as[Json].unsafeRunSync()
+
+        inside(json.asObject.value) {
+          jsonObject => inside(jsonObject("error").value) {
+            error => error.asString should be(Some("invalid_grant"))
+          }
+        }
+      }
+
+      "exchange for token with only client secret" in {
+        val request: Request[IO] = Request(method = Method.POST)
+          .putHeaders(Authorization(BasicCredentials(client1.name, client1.secret)))
+          .withEntity(UrlForm(
+            ("grant_type", "authorization_code"),
+            ("code", codeWithoutRedirectWithoutPKCE.uuid.toString)))
+
+        val response = exchange.run(request).unsafeRunSync()
+
+        response.status should be(Status.Ok)
+      }
+
+      "exchange for token with client secret and PKCE" in {
+        val request: Request[IO] = Request(method = Method.POST)
+          .putHeaders(Authorization(BasicCredentials(client2.name, client2.secret)))
+          .withEntity(UrlForm(
+            ("grant_type", "authorization_code"),
+            ("code", codeWithPlainPKCE.uuid.toString),
+            ("code_verifier", plainProofKey)))
+
+        val response = exchange.run(request).unsafeRunSync()
+
+        response.status should be(Status.Ok)
+      }
+
+      "decline exchange for token with faulty client secret and valid PKCE" in {
+        val request: Request[IO] = Request(method = Method.POST)
+          .putHeaders(Authorization(BasicCredentials(client1.name, client1.secret)))
+          .withEntity(UrlForm(
+            ("grant_type", "authorization_code"),
+            ("code", codeWithPlainPKCE.uuid.toString),
+            ("code_verifier", plainProofKey)))
+
+        val response = exchange.run(request).unsafeRunSync()
+
+        response.status should be(Status.BadRequest)
+
+        val json = response.as[Json].unsafeRunSync()
+
+        inside(json.asObject.value) {
+          jsonObject =>
+            inside(jsonObject("error").value) {
+              error => error.asString should be(Some("invalid_grant"))
+            }
+        }
+      }
+
+      "exchange for token with only PKCE" in {
+        val request: Request[IO] = Request(method = Method.POST)
+          .putHeaders(Authorization(BasicCredentials(client2.name, "")))
+          .withEntity(UrlForm(
+            ("grant_type", "authorization_code"),
+            ("code", codeWithoutRedirectWithoutPKCE.uuid.toString),
+            ("code_verifier", plainProofKey)))
+
+        val response = exchange.run(request).unsafeRunSync()
+
+        response.status should be(Status.Ok)
+      }
+    }
+  }
+}

--- a/core/src/test/scala/se/su/dsv/oauth/endpoint/ExchangeSuite.scala
+++ b/core/src/test/scala/se/su/dsv/oauth/endpoint/ExchangeSuite.scala
@@ -30,11 +30,11 @@ class ExchangeSuite extends AnyWordSpec with Matchers with Inside with OptionVal
       val codeWithoutRedirectWithoutPKCE = Code(None, UUID.randomUUID(), payload, None)
       val codeWithRedirectWithoutPKCE = Code(Some(localhost), UUID.randomUUID(), payload, None)
 
-      val plainProofKey = "plain-proof-key"
-      val codeWithPlainPKCE = Code(None, UUID.randomUUID(), payload, Some(ProofKey.Plain(plainProofKey)))
+      val plainCodeVerifier = "plain-key"
+      val codeWithPlainPKCE = Code(None, UUID.randomUUID(), payload, Some(CodeChallenge.Plain(plainCodeVerifier)))
 
       val sha256CodeVerifier = "averylongstringthatwillbehashedwithsha256"
-      val codeWithSha256PKCE = Code(None, UUID.randomUUID(), payload, Some(ProofKey.Sha256("Je2tyc_cm4NjBaZHTJDcwD2uNtSD-yQSaJX0tUMRdqg")))
+      val codeWithSha256PKCE = Code(None, UUID.randomUUID(), payload, Some(CodeChallenge.Sha256("Je2tyc_cm4NjBaZHTJDcwD2uNtSD-yQSaJX0tUMRdqg")))
 
       val token = GeneratedToken(Token("token"), Duration.ofHours(1))
 
@@ -86,7 +86,7 @@ class ExchangeSuite extends AnyWordSpec with Matchers with Inside with OptionVal
           .withEntity(UrlForm(
             ("grant_type", "authorization_code"),
             ("code", codeWithPlainPKCE.uuid.toString),
-            ("code_verifier", plainProofKey)))
+            ("code_verifier", plainCodeVerifier)))
 
         val response = exchange.run(request).unsafeRunSync()
 
@@ -99,7 +99,7 @@ class ExchangeSuite extends AnyWordSpec with Matchers with Inside with OptionVal
           .withEntity(UrlForm(
             ("grant_type", "authorization_code"),
             ("code", codeWithPlainPKCE.uuid.toString),
-            ("code_verifier", plainProofKey)))
+            ("code_verifier", plainCodeVerifier)))
 
         val response = exchange.run(request).unsafeRunSync()
 
@@ -112,7 +112,7 @@ class ExchangeSuite extends AnyWordSpec with Matchers with Inside with OptionVal
           .withEntity(UrlForm(
             ("grant_type", "authorization_code"),
             ("code", codeWithPlainPKCE.uuid.toString),
-            ("code_verifier", plainProofKey)))
+            ("code_verifier", plainCodeVerifier)))
 
         val response = exchange.run(request).unsafeRunSync()
 

--- a/production/src/main/scala/se/su/dsv/oauth/Main.scala
+++ b/production/src/main/scala/se/su/dsv/oauth/Main.scala
@@ -43,7 +43,7 @@ class Main extends ServletContextListener {
 
     mountService(ctx,
       name = "authorize",
-      service = new Authorize(backend.lookupClient, backend.generateToken, backend.generateCode).service,
+      service = new Authorize(backend.lookupClient, backend.generateCode).service,
       mapping = "/authorize")
 
     mountService(ctx,

--- a/production/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/production/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -12,9 +12,8 @@ import se.su.dsv.oauth._
 class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
-  generateToken: Payload => F[GeneratedToken],
   generateCode: (String, Option[Uri], Payload) => F[Code]
-) extends AbstractAuthorize[F](lookupClient, generateToken, generateCode)
+) extends AbstractAuthorize[F](lookupClient, generateCode)
 {
 
   private def validateNonce(form: UrlForm, request: Request[F]): OptionT[F, Unit] = {

--- a/production/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/production/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -12,7 +12,7 @@ import se.su.dsv.oauth._
 class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
-  generateCode: (String, Option[Uri], Payload, Option[ProofKey]) => F[Code]
+  generateCode: (String, Option[Uri], Payload, Option[CodeChallenge]) => F[Code]
 ) extends AbstractAuthorize[F](lookupClient, generateCode)
 {
 

--- a/production/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/production/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -12,7 +12,7 @@ import se.su.dsv.oauth._
 class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
-  generateCode: (String, Option[Uri], Payload) => F[Code]
+  generateCode: (String, Option[Uri], Payload, Option[ProofKey]) => F[Code]
 ) extends AbstractAuthorize[F](lookupClient, generateCode)
 {
 

--- a/staging/src/main/scala/se/su/dsv/oauth/Main.scala
+++ b/staging/src/main/scala/se/su/dsv/oauth/Main.scala
@@ -44,7 +44,7 @@ class Main extends ServletContextListener {
 
     mountService(ctx,
       name = "authorize",
-      service = new Authorize(backend.lookupClient, backend.generateToken, backend.generateCode).service,
+      service = new Authorize(backend.lookupClient, backend.generateCode).service,
       mapping = "/authorize")
 
     mountService(ctx,

--- a/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -15,17 +15,14 @@ sealed trait AuthorizeError
 case object NotDeveloper extends AuthorizeError
 final case class BadInput(decodeFailure: DecodeFailure) extends AuthorizeError
 case object InvalidAuthorizationRequest extends AuthorizeError
-final case class NoSuchClient(clientId: String) extends AuthorizeError
-final case class InvalidScopes(requested: Set[String], allowed: Set[String]) extends AuthorizeError
-final case class InvalidRedirectUri(requested: Option[Uri], allowed: Uri) extends AuthorizeError
 case object MissingPrincipal extends AuthorizeError
 
-class Authorize[F[_]]
+class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
   generateToken: Payload => F[GeneratedToken],
   generateCode: (String, Option[Uri], Payload) => F[Code]
-)(implicit S: Concurrent[F]) extends Http4sDsl[F] {
+)extends AbstractAuthorize[F](lookupClient, generateToken, generateCode) {
 
   def service: HttpRoutes[F] = HttpRoutes.of {
     case request @ GET -> Root =>
@@ -44,78 +41,23 @@ class Authorize[F[_]]
         authorizationRequest <- AuthorizationRequest.fromForm(form)
             .toOptionT
             .toRight(InvalidAuthorizationRequest)
-        client <- lookupClient(authorizationRequest.clientId)
-            .toRight(NoSuchClient(authorizationRequest.clientId))
-        _ <- validateScopes(authorizationRequest.scopes, client.allowedScopes)
-            .toRight(InvalidScopes(
-              requested = authorizationRequest.scopes,
-              allowed = client.allowedScopes
-            ))
-        redirectUri <- validateRedirectUri(authorizationRequest.redirectUri, client.redirectUri)
-            .toRight(InvalidRedirectUri(
-              requested = authorizationRequest.redirectUri,
-              allowed = client.redirectUri
-            ))
         payload <- toPayload(form)
             .toOptionT
             .toRight(MissingPrincipal)
-        callbackUri <- EitherT.liftF[F, AuthorizeError, Uri](authorizationRequest.responseType match {
-          case ResponseType.Code =>
-            for {
-              code <- generateCode(authorizationRequest.clientId, authorizationRequest.redirectUri, payload)
-            } yield redirectUri +*? code +?? ("state", authorizationRequest.state)
-          case ResponseType.Token =>
-            generateToken(payload) map { token =>
-              val parameters = Map(
-                "access_token" -> token.token.token,
-                "token_type" -> "Bearer",
-                "expires_in" -> String.valueOf(token.duration.getSeconds),
-                "state" -> authorizationRequest.state.getOrElse("")
-              )
-              redirectUri.copy(
-                fragment = Some(parameters.foldLeft("") { case (s, (key, value)) => s"$s&$key=$value" })
-              )
-            }
-        })
-      } yield callbackUri
+        response <- EitherT.liftF(authorize(authorizationRequest, payload))
+      } yield response
       response.value.flatMap {
-        case Right(callbackUri) => SeeOther(Location(callbackUri))
+        case Right(response) => response.pure[F]
         case Left(error) => Forbidden(error.toString)
       }
   }
 
-  def validateDeveloperAccess(request: Request[F]): OptionT[F, Unit] = {
+  private def validateDeveloperAccess(request: Request[F]): OptionT[F, Unit] = {
     request.attributes
       .lookup(EntitlementsKey)
       .filter(_.hasEntitlement(developerEntitlement))
       .toOptionT
       .void
-  }
-
-  def validateRedirectUri(requestedRedirectUri: Option[Uri], configuredRedirectUri: Uri): OptionT[F, Uri] = {
-    val redirectUri = requestedRedirectUri getOrElse configuredRedirectUri
-    if (redirectUri == configuredRedirectUri)
-      some(redirectUri)
-    else
-      none
-  }
-
-  def validateScopes(requestedScopes: Set[String], allowedScopes: Set[String]): OptionT[F, Set[String]] = {
-    if (requestedScopes.forall(allowedScopes))
-      some[F](requestedScopes)
-    else
-      none
-  }
-
-  def validateNonce(form: UrlForm, request: Request[F]): OptionT[F, Unit] = {
-    val formNonce = form.getFirst("nonce")
-    val cookieNonce = request.headers.get[Cookie].flatMap(_.values.collectFirst {
-      case RequestCookie(name, content) if name == "nonce" => content
-    })
-    if (formNonce.exists(s => cookieNonce.contains(s)))
-      some(())
-    else
-      none
   }
 
   private def toPayload(form: UrlForm): Option[Payload] = {

--- a/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -20,9 +20,8 @@ case object MissingPrincipal extends AuthorizeError
 class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
-  generateToken: Payload => F[GeneratedToken],
   generateCode: (String, Option[Uri], Payload) => F[Code]
-)extends AbstractAuthorize[F](lookupClient, generateToken, generateCode) {
+)extends AbstractAuthorize[F](lookupClient, generateCode) {
 
   def service: HttpRoutes[F] = HttpRoutes.of {
     case request @ GET -> Root =>

--- a/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -20,7 +20,7 @@ case object MissingPrincipal extends AuthorizeError
 class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
-  generateCode: (String, Option[Uri], Payload) => F[Code]
+  generateCode: (String, Option[Uri], Payload, Option[ProofKey]) => F[Code]
 )extends AbstractAuthorize[F](lookupClient, generateCode) {
 
   def service: HttpRoutes[F] = HttpRoutes.of {

--- a/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
+++ b/staging/src/main/scala/se/su/dsv/oauth/endpoint/Authorize.scala
@@ -20,7 +20,7 @@ case object MissingPrincipal extends AuthorizeError
 class Authorize[F[_] : Concurrent]
 (
   lookupClient: String => OptionT[F, Client],
-  generateCode: (String, Option[Uri], Payload, Option[ProofKey]) => F[Code]
+  generateCode: (String, Option[Uri], Payload, Option[CodeChallenge]) => F[Code]
 )extends AbstractAuthorize[F](lookupClient, generateCode) {
 
   def service: HttpRoutes[F] = HttpRoutes.of {


### PR DESCRIPTION
Fixes #1

Clients configured as public will require PKCE. Public clients still have to provide their `client id` using HTTP basic authorization, the password part is ignored.

Confidential clients can use PKCE but it is not required.